### PR TITLE
Updated grid ratio

### DIFF
--- a/config/apodizer_spec.txt
+++ b/config/apodizer_spec.txt
@@ -2,16 +2,18 @@
 #Currently, the primary purpose is to supply the satellite spot flux ratios for different apodizers
 #Potentially, may be expanded to include other apodizer-specific values (?)
 #
-#Name   gridfac
-APOD_CLEAR_G6201    NaN
-APOD_CLEARGP_G6202  NaN
-APOD_Y_G6203    2.345e-4
-APOD_J_G6204    1.7975e-4
-APOD_H_G6205    2.035e-4
-APOD_K1_G6206   2.695e-4
-APOD_K2_G6207   1.905e-4
-APOD_NRM_G6208  1e-4
-APOD_HL_G6209   1e-4
-APOD_HSTAR_G6210    1e-4
-Unknown     NaN
-User Defined    1e-4
+#Name   gridfac   order
+APOD_CLEAR_G6201    NaN   1
+APOD_CLEARGP_G6202  NaN   1
+APOD_Y_G6203    1.60e-4   1
+APOD_Y_G6203    1.42e-4   2
+APOD_J_G6204    1.84e-4   1
+APOD_J_G6204    1.47e-4   2
+APOD_H_G6205    1.74e-4   1
+APOD_K1_G6206   2.12e-4   1
+APOD_K2_G6207   1.905e-4   1
+APOD_NRM_G6208  1e-4   1
+APOD_HL_G6209   1e-4   1
+APOD_HSTAR_G6210    1e-4   1
+Unknown     NaN   1
+User Defined    1e-4   1

--- a/config/apodizer_spec.txt
+++ b/config/apodizer_spec.txt
@@ -1,6 +1,7 @@
 #Apodizer specific quantities.
 #Currently, the primary purpose is to supply the satellite spot flux ratios for different apodizers
 #Potentially, may be expanded to include other apodizer-specific values (?)
+#Reference - https://www.gemini.edu/sciops/instruments/gpi/instrument-performance/satellite-spots
 #
 #Name   gridfac   order
 APOD_CLEAR_G6201    NaN   1

--- a/gpitv/gpitv__define.pro
+++ b/gpitv/gpitv__define.pro
@@ -8277,7 +8277,11 @@ pro GPItv::setheadinfo, noresize=noresize
         if res[1] ne '' then val = res[1]
       endif
     endif
-    (*self.state).gridfac = gpi_get_gridfac(val)
+    val2 = gpi_get_keyword(h, e, 'SATSORDR', count=cc1, silent=silent)
+    if cc1 eq 0 then sat_order = 1 else begin
+        sat_order = val2
+    endelse
+    (*self.state).gridfac = gpi_get_gridfac(val, sat_order))
   endelse
 
   if xregistered(self.xname+'_contrprof',/noshow) then $

--- a/gpitv/gpitv__define.pro
+++ b/gpitv/gpitv__define.pro
@@ -8281,7 +8281,7 @@ pro GPItv::setheadinfo, noresize=noresize
     if cc1 eq 0 then sat_order = 1 else begin
         sat_order = val2
     endelse
-    (*self.state).gridfac = gpi_get_gridfac(val, sat_order))
+    (*self.state).gridfac = gpi_get_gridfac(val, sat_order)
   endelse
 
   if xregistered(self.xname+'_contrprof',/noshow) then $

--- a/primitives/gpi_calibrate_photometric_flux_pol.pro
+++ b/primitives/gpi_calibrate_photometric_flux_pol.pro
@@ -59,7 +59,9 @@ if f_star eq 0. then $
 
 ;; Read in the sat spot to star flux ratio
 apodizer = backbone->get_keyword('APODIZER')      ; apodizer used
-gridfac = gpi_get_gridfac(apodizer)               ; sat spot to star flux ratio
+sat_order = backbone->get_keyword('SATSORDR', ext_num=1, count=ct, /silent) ; which order
+if ct eq 0 then sat_order = 1
+gridfac = gpi_get_gridfac(apodizer, sat_order)               ; sat spot to star flux ratio
 
 
 CATCH, Error_status

--- a/primitives/gpi_insert_planet_into_cube.pro
+++ b/primitives/gpi_insert_planet_into_cube.pro
@@ -77,8 +77,9 @@ suffix='wplnt' 		 ; set this to the desired output filename suffix
 	; satellite spot flux ratios
 	val = (backbone->get_keyword('APODIZER')) 
 	if strc(string(val)) eq '0' or val eq 'CLEAR' or val eq 'CLEAR_GP' then return, error('FAILURE ('+functionName+'): Apodizer not properly defined, or apodizer set to CLEAR or CLEAR_GP which will not have satellite spots, therefore no planet can be properly input into the cube')
-
-	gridfac=gpi_get_gridfac(val) ; satellite spot ratios
+	sat_order = backbone->get_keyword('SATSORDR', ext_num=1, count=ct, /silent) ; which order
+	if ct eq 0 then sat_order = 1
+	gridfac=gpi_get_gridfac(val, sat_order) ; satellite spot ratios
 
 ; ################################################################################
 ; Pull the psf from a satellite spot - will be used as planet later

--- a/primitives/gpi_klip_adi_plus_sdi.pro
+++ b/primitives/gpi_klip_adi_plus_sdi.pro
@@ -425,7 +425,7 @@ endfor
 
 	 backbone->set_keyword, 'PSFSUB', 'GPI DRP KLIP ADI+SDI', 'PSF subtraction via KLIP ADI+SDI'
 	 backbone->set_keyword, 'PSFPARAM', "annuli"+strc(annuli)+" subsections="+strc(subsections)+" prop="+strc(prop)+" minsep="+strc(minsep)+$
-										"minPA="+strc(minPA)+" waveclip="+strc(waveclip)+" numthreads="+strc(numthreads)., "PSF sub. parameters"
+										"minPA="+strc(minPA)+" waveclip="+strc(waveclip)+" numthreads="+strc(numthreads), "PSF sub. parameters"
 
 
 

--- a/primitives/gpi_measure_contrast.pro
+++ b/primitives/gpi_measure_contrast.pro
@@ -104,7 +104,11 @@ primitive_version= '$Id$' ; get version from subversion to store in header histo
       if res[1] ne '' then apodizer = res[1]
     endif
   endif
-  gridfac = gpi_get_gridfac(apodizer)
+
+  sat_order = backbone->get_keyword('SATSORDR', ext_num=1, count=ct, /silent) ; which order
+  if ct eq 0 then sat_order = 1
+
+  gridfac = gpi_get_gridfac(apodizer, sat_order)
   if ~finite(gridfac) then return, error('FAILURE ('+functionName+'): Could not match apodizer.')
 
   ;;get user inputs

--- a/primitives/gpi_measure_contrast_pol.pro
+++ b/primitives/gpi_measure_contrast_pol.pro
@@ -169,7 +169,11 @@ function gpi_measure_contrast_pol, DataSet, Modules, Backbone
       if res[1] ne '' then apodizer = res[1]
     endif
   endif
-  gridfac = gpi_get_gridfac(apodizer)
+
+  sat_order = backbone->get_keyword('SATSORDR', ext_num=1, count=ct, /silent) ; which order
+  if ct eq 0 then sat_order = 1
+
+  gridfac = gpi_get_gridfac(apodizer, sat_order)
   if ~finite(gridfac) then return, error('FAILURE ('+functionName+'): Could not match apodizer.')
 
   ;;get user inputs

--- a/primitives/gpi_measure_satellite_spot_flux_pol.pro
+++ b/primitives/gpi_measure_satellite_spot_flux_pol.pro
@@ -105,7 +105,6 @@ function gpi_measure_satellite_spot_flux_pol, DataSet, Modules, Backbone
   ;Are we using 2nd order sat spots?
   secOrder=fix(Modules[thisModuleIndex].SecondOrder)
 
-
   IF strmatch(mode,"*wollaston*",/fold) THEN BEGIN
 
     if verbose then begin
@@ -450,6 +449,9 @@ function gpi_measure_satellite_spot_flux_pol, DataSet, Modules, Backbone
   ;
   case reduction_level of
     1: begin
+      ;Record which order of spots are used.
+      backbone->set_keyword, 'SATSORDR', secOrder+1, 'Sat spot grid order used (1:primary or 2:secondary)', ext_num=1
+      
       ;Put in the theoretical location of the center of the satellite spots
       ;SLICE0
       backbone->set_keyword, 'SAT0_0', string(strtrim([xs0,ys0],2),format='(F7.3," ",F7.3)'),'Location of sat. spot 0 of slice 0', ext_num=1
@@ -515,6 +517,9 @@ function gpi_measure_satellite_spot_flux_pol, DataSet, Modules, Backbone
 
       for i=0,nfiles-1 do begin
         tmp=accumulate_getimage(dataset,i,hdr,hdrext=hdrext)
+        ;Record which order of spots are used.
+        sxaddpar, hdrext,  'SATSORDR', secOrder+1, 'Sat spot grid order used (1:primary or 2:secondary)'
+
         ;Put in the theoretical location of the center of the satellite spots
         ;SLICE0
         sxaddpar, hdrext,  'SAT0_0', string(strtrim([xs0,ys0],2),format='(F7.3," ",F7.3)'),'Location of sat. spot 0 of slice 0'

--- a/utils/gpi_get_gridfac.pro
+++ b/utils/gpi_get_gridfac.pro
@@ -6,10 +6,11 @@ function gpi_get_gridfac,apodizer,spot_order
 ;       Return apodizer scaling value from lookup table
 ;
 ; CALLING SEQUENCE:
-;       res = gpi_get_gridfac(apodizer)
+;       res = gpi_get_gridfac(apodizer, spot_order)
 ;
 ; INPUT/OUTPUT:
 ;       apodizer - Name of apodizer (typically from image header)
+;       spot_order - First or second order (for Y/J datasets)
 ;       res - gridfac value (or NaN if lookup table couldn't be
 ;             found, or apodizer couldn't be matched, or
 ;             apodizer has no grid).

--- a/utils/gpi_get_gridfac.pro
+++ b/utils/gpi_get_gridfac.pro
@@ -1,4 +1,4 @@
-function gpi_get_gridfac,apodizer
+function gpi_get_gridfac,apodizer,spot_order
 ;+
 ; NAME:
 ;       gpi_get_gridfac
@@ -33,15 +33,18 @@ function gpi_get_gridfac,apodizer
 
 compile_opt defint32, strictarr, logical_predicate
 
+;; if spot_order is invalid, set it to 1
+if spot_order gt 2 then spot_order = 1
+
 fname = gpi_expand_path(gpi_get_setting('apodizer_spec',default=gpi_get_directory('GPI_DRP_CONFIG_DIR')+'/apodizer_spec.txt',/silent))
 if ~file_test(fname) then begin
    message,'Could not find apodizer spec file.',/continue
    return,!values.f_nan
 endif
 
-readcol, fname, format='A,F', comment='#', names, values, count=count, /silent
+readcol, fname, format='A,F,I', comment='#', names, values, order, count=count, /silent
 
-res = where(strmatch(names,'*'+apodizer+'*',/fold_case),cc)
+res = where(strmatch(names,'*'+apodizer+'*',/fold_case) and (order eq spot_order),cc)
 if cc ne 1 then begin
    message,'Could not match apodizer name.',/continue
    return,!values.f_nan

--- a/utils/gpi_photometric_calibration_calculation.pro
+++ b/utils/gpi_photometric_calibration_calculation.pro
@@ -216,7 +216,11 @@ endif ; if ref_model_spectrum eq 0
 ; correct for the satellite to star flux ratio if desired
 	if keyword_set(no_satellite_correction) eq 0 then begin
 		apodizer=sxpar(pri_header,'APODIZER')
-		gridfac = gpi_get_gridfac(apodizer)
+		
+		sat_order = backbone->get_keyword('SATSORDR', ext_num=1, count=ct, /silent) ; which order
+		if ct eq 0 then sat_order = 1
+
+		gridfac = gpi_get_gridfac(apodizer, sat_order)
 		gpi_model_flux*=gridfac
 	endif
 


### PR DESCRIPTION
Modified the apodizer specification file with updated grid ratios and new second-order ratios. Pipeline should now read the SATSORDR keyword to determine which were used.